### PR TITLE
Align Typescript output with EB-repo

### DIFF
--- a/tsconfig.tsc.json
+++ b/tsconfig.tsc.json
@@ -7,7 +7,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "./dist",
-    "target": "esnext"
+    "target": "es6"
   },
   "indent": [true, "spaces", 2],
   "exclude": ["./node_modules"],


### PR DESCRIPTION
The special ESNext value refers to the highest version your version of TypeScript supports. This setting should be used with caution, since it doesn’t mean the same thing between different TypeScript versions and can make upgrades less predictable.